### PR TITLE
Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
+.vs
 build
 *.egg*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,18 @@ set(DFMTOOLBOX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/src/python/dfmtoolbox)
 
 # Build fftw3 as a shared lib
 add_subdirectory(lib/fftw-3.3.10)
-set_target_properties(fftw3 PROPERTIES
-                        PREFIX ""
-                        SUFFIX ".so"
-                        LIBRARY_OUTPUT_DIRECTORY ${DFMTOOLBOX_OUTPUT_DIR}
+
+if(WIN32)
+    set_target_properties(fftw3 PROPERTIES
+                            RUNTIME_OUTPUT_DIRECTORY_RELEASE ${DFMTOOLBOX_OUTPUT_DIR}
+                        )
+else()
+    set_target_properties(fftw3 PROPERTIES
+                            PREFIX ""
+                            SUFFIX ".so"
+                            LIBRARY_OUTPUT_DIRECTORY ${DFMTOOLBOX_OUTPUT_DIR}
                     )
+endif(WIN32)
 
 # Build with python3 bindings
 find_package(PythonLibs 3 REQUIRED)
@@ -35,6 +42,8 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+#message(FATAL_ERROR "This is output_dir: ${DFMTOOLBOX_OUTPUT_DIR}")
 
 # Add project library subdirectory
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,10 +21,16 @@ set_target_properties(_dfmtoolbox PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # Add core python module
 pybind11_add_module(core SHARED python/bindings.cc)
 target_link_libraries(core PRIVATE _dfmtoolbox)
-set_target_properties(core PROPERTIES
-                            SUFFIX ".so"
-                            LIBRARY_OUTPUT_DIRECTORY ${DFMTOOLBOX_OUTPUT_DIR}
-                    )       
+if(WIN32)
+    set_target_properties(core PROPERTIES
+                                RUNTIME_OUTPUT_DIRECTORY_RELEASE ${DFMTOOLBOX_OUTPUT_DIR}
+                        )
+else()
+    set_target_properties(core PROPERTIES
+                                SUFFIX ".so"
+                                LIBRARY_OUTPUT_DIRECTORY ${DFMTOOLBOX_OUTPUT_DIR}
+                        )
+endif()
 
 # Copy the files required to install the library with python's setuptools
 configure_file(python/__init__.py


### PR DESCRIPTION
This PR addresses the setup issue on different OSs, which was related to bad library linking after installation.
I performed tests on Linux (Ubuntu 20.04), MacOS and Windows.
I found that (on Windows, using the just released python 3.11) scikit-image cannot be installed. This will be probably fixed by the scikit developers, I will just mention it here for future reference.