### PR TITLE
FIX: passed param objects/dicts will not be altered by the function

### DIFF
--- a/src/python/fit.py
+++ b/src/python/fit.py
@@ -207,8 +207,14 @@ def fit_multik(
         whose second value is the complete list of `lmfit.ModelResult`s
         obtained.
     """
+    from copy import deepcopy
+
     # initialize model parameters
     model_params = model.make_params()
+
+    # create deep copies of passed parameters:
+    ref_params = deepcopy(ref_params) if ref_params is not None else None
+    fixed_params = deepcopy(fixed_params) if fixed_params is not None else None
 
     # we require the models to have one and one only independent variable
     indep_var = model.independent_vars[0]


### PR DESCRIPTION
Passing the arguments `ref_params` and running the `fit_multik` multiple times changed the original `ref_params` object (because they were passed by reference). Now, inside the function they are deepcopied to prevent this from happening so a re-run of `fit_multik` will then still use the original `ref_params`. 

To be safe, a deepcopy of the `fixed_params` dictionary is also created.