### PR TITLE
Add lmfit to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     'scikit-image',
     'tifffile',
     'nd2reader',
-    'pandas'
+    'pandas',
+    'lmfit'
 ]
 dynamic = [ "license", "version" ]


### PR DESCRIPTION
Now that the lmfit library switched to pyproject.toml standard, it is possible to install it via the dependencies.

Close #164 