### PR TITLE
Specify CUDA Toolkit version used when loading DLLs in Windows

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -28,7 +28,11 @@ if IS_CUDA_ENABLED:
     if sys.platform == "win32":
         import os
 
-        os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "bin"))
+        # Get the CUDA Toolkit version
+        cuda_version = CUDA_VERSION.replace(".", "_")
+        os.add_dll_directory(
+            os.path.join(os.environ["CUDA_PATH_V" + cuda_version], "bin")
+        )
 
 from ._ddm import ddm
 from .azimuthalaverage import azimuthal_average

--- a/src/python/_config.py
+++ b/src/python/_config.py
@@ -8,7 +8,9 @@
 import numpy as np
 
 IS_CPP_ENABLED = True  # configured by CMake
-IS_CUDA_ENABLED = True  # configured by CMake
+IS_CUDA_ENABLED = False  # configured by CMake
 IS_SINGLE_PRECISION = False  # configured by CMake
+
+CUDA_VERSION = ""  # configured by CMake
 
 DTYPE = np.float32 if IS_SINGLE_PRECISION else np.float64

--- a/src/python/_config.py.in
+++ b/src/python/_config.py.in
@@ -11,4 +11,6 @@ IS_CPP_ENABLED = ${IS_CPP_ENABLED}              # configured by CMake
 IS_CUDA_ENABLED = ${IS_CUDA_ENABLED}            # configured by CMake
 IS_SINGLE_PRECISION = ${IS_SINGLE_PRECISION}    # configured by CMake
 
+CUDA_VERSION = "${CUDAToolkit_VERSION}"         # configured by CMake
+
 DTYPE = np.float32 if IS_SINGLE_PRECISION else np.float64


### PR DESCRIPTION
This PR aims at making the package more stable against CUDA Toolkit updates by specifying the version linked against during installation during DLL loading in Windows.

Close #183 