### PR TITLE
Fix bug with input bins list in azimuthal average

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,20 @@ Change Log
 v0.3
 ----
 
+v0.3.2 (2024-03-06)
+^^^^^^^^^^^^^^^^^^^
+
+.. *Added*
+
+.. *Changed*
+
+*Fixed*
+
+* Resolved bug where list input in ``azimuthal_average`` was throwing an error
+
+.. *Deprecated*
+.. *Removed*
+
 v0.3.1 (2024-03-05)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/src/python/azimuthalaverage.py
+++ b/src/python/azimuthalaverage.py
@@ -397,7 +397,7 @@ def azimuthal_average_array(
         # check if it is a monotonically increasing array
         if not np.all(bins[1:] >= bins[:-1]):
             raise ValueError("bins must be monotonically increasing.")
-        bin_edges = bins.astype(DTYPE)
+        bin_edges = np.array(bins).astype(DTYPE)
         n_bins = len(bins)
         x_min = bins[0]
     else:


### PR DESCRIPTION
This PR fixes a bug where inputting a list in the ``bins`` argument of ``azimuthal_average`` would throw an error.
It also adds a test for the azimuthal average.
Closes #193 