### PR TITLE
V0.3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,17 @@ Change Log
 v0.3
 ----
 
-v0.3.4 (YYYY-MM-DD)
+v0.3.5 (2024-03-28)
 ^^^^^^^^^^^^^^^^^^^
 
 .. *Added*
 
 .. *Changed*
-.. *Fixed*
+
+*Fixed*
+
+* Due to PyPI maintainance, ``v0.3.4`` was not published to the package index. It should happen now.
+
 .. *Deprecated*
 .. *Removed*
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ Change Log
 v0.3
 ----
 
+v0.3.4 (YYYY-MM-DD)
+^^^^^^^^^^^^^^^^^^^
+
+.. *Added*
+
+.. *Changed*
+.. *Fixed*
+.. *Deprecated*
+.. *Removed*
+
 v0.3.4 (2024-03-28)
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is a dummy release.
Due to PyPI maintenance (malware campaign), no new projects could be created.
This release should solve this.