### PR TITLE
Fix Windows PyPI wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [["cp38", "3.8"], ["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
 
     steps:
       - name: Checkout code
@@ -55,7 +55,8 @@ jobs:
           CIBW_ENVIRONMENT: ENABLE_CPP=ON
 
           # Manually select the python version
-          CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version }}.*"
+          CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version[1] }}.*"
+          CIBW_BUILD: "${{ matrix.python-version[0] }}-*"
           CIBW_SKIP: "{pp*,*-musllinux_*}"
 
           # Build only for 64-bit platforms

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+  # trigger on request
+  workflow_dispatch:
+
 jobs:
   build_sdist:
     name: Build source distribution


### PR DESCRIPTION
## Description

This PR adds manual specification of the Python version against which wheels are built.
It also introduces the possibility to trigger the wheel creation workflow manually.

## Motivation and context

On Windows, we could not import the ``fastddm`` library correctly when it was installed using the wheels from PyPI.
The shared ``_core`` library was compiled with the wrong Python version.

Resolves #221 

## How has this been tested?

Not tested, requires manual triggering which is introduced here.

## Change log

<!-- Propose a change log entry. -->
```
* Fixes

* Windows wheels for ``python!=3.9`` work properly now.
```
