### PR TITLE
Update install procedure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change Log
 v0.3
 ----
 
+v0.3.13 (2025-05-09)
+
+*Fixed*
+
+* Installation issues on Ubuntu due to CMake versions &lt; 3.5 being deprecated.
+* Fixed documentation with cuda packages name changes
+
 v0.3.12 (2024-06-25)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 4.0.0)
 
 option(ENABLE_CPP "Set to ON to compile with C++ support" OFF)
 option(ENABLE_CUDA "Set to ON to compile with CUDA support" OFF)

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2023-2023 University of Vienna, Enrico Lattuada, Fabian Krautgasser, and Roberto Cerbino.
+.. Copyright (c) 2023-2025 University of Vienna, Enrico Lattuada, Fabian Krautgasser, Maxime Lavaud and Roberto Cerbino.
 .. Part of FastDDM, released under the GNU GPL-3.0 License.
 
 .. _build:
@@ -110,6 +110,10 @@ First and foremost, you will need a CUDA-capable GPU.
 Check your hardware compatibility on the `NVIDIA website <https://developer.nvidia.com/cuda-gpus>`_.
 Follow the `instructions <https://docs.nvidia.com/cuda/>`_ available from the website specific to your OS.
 Notice that CUDA is not available for MacOS.
+
+**To build the CUDA core:**
+
+Please set the ``CUDAXCC`` environment variable with the path of the  ``nvcc`` compiler.
 
 **To build the documentation:**
 

--- a/docs/source/conda.rst
+++ b/docs/source/conda.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2023-2023 University of Vienna, Enrico Lattuada, Fabian Krautgasser, and Roberto Cerbino.
+.. Copyright (c) 2023-2025 University of Vienna, Enrico Lattuada, Fabian Krautgasser, Maxime Lavaud and Roberto Cerbino.
 .. Part of FastDDM, released under the GNU GPL-3.0 License.
 
 .. _conda:
@@ -43,8 +43,9 @@ system).
           name: fddm-env
           channels:
             - defaults
+            - conda-forge
           dependencies:
-            - gcc
+            - gcc=14
             - g++
             - python>=3.8
             - pip
@@ -73,6 +74,18 @@ system).
       .. code-block:: bash
 
           $ conda env config vars set ENABLE_CPP=ON
+
+      To compile the CUDA core, set the corresponding flag
+
+      .. code-block:: bash
+
+          $ conda env config vars set ENABLE_CUDA=ON
+    
+      Path to the CUDA Toolkit should also be exported
+
+      .. code-block:: bash
+
+          $ conda env config vars set CUDACXX=/usr/local/cuda_version/bin/nvcc
 
       Deactivate and reactivate the environment to make the changes effective
 

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2023-2023 University of Vienna, Enrico Lattuada, Fabian Krautgasser, and Roberto Cerbino.
+.. Copyright (c) 2023-2025 University of Vienna, Enrico Lattuada, Fabian Krautgasser, Maxime Lavaud and Roberto Cerbino.
 .. Part of FastDDM, released under the GNU GPL-3.0 License.
 
 License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=47",
     "setuptools_scm",
     "wheel",
-    "cmake>=3.18",
+    "cmake>=4.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -14,11 +14,13 @@ readme = "README.md"
 authors = [
     { name = "Enrico Lattuada" },
     { name = "Fabian Krautgasser" },
+    { name = "Maxime Lavaudd"},
     { name = "Roberto Cerbino" },
     { email = "cerbino@gmail.com" },
 ]
 maintainers = [
     { name = "Enrico Lattuada", email = "lattuada.enrico@gmail.com" },
+    { name = "Maxime Lavaud", email = "lavaudmaxime.ml@gmail.com" },
 ]
 requires-python = ">=3.8"
 dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ class CMakeBuild(build_ext):
 setup(
     name="fastddm",
     use_scm_version={
-        "fallback_version": "0.3.12",
+        "fallback_version": "0.3.13",
     },
     packages=find_packages(),
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,8 @@ class CMakeBuild(build_ext):
         self.announce("Preparing the build environment", level=3)
 
         cmake_args = []
+        # Workaround since fftw not using the corect version of cmake
+        cmake_args += ["-DCMAKE_POLICY_VERSION_MINIMUM=4.0.0"]
 
         cfg = "Debug" if self.debug else "Release"
         build_args = ["--config", cfg]


### PR DESCRIPTION
## Description

Due to some updates of GCC and cmake the installation was broken

## Motivation and context

i) Limit the GCC version to 14 as the 15 is not yet compatible with nvcc.
ii) Forcing the minimal version of cmake to be 3.5 in the subcompilation as fftw use a too old version.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

using pytest
