### PR TITLE
274 dev add support for cuda toolkit 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,24 @@ env:
   UV_SYSTEM_PYTHON: 1
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      gpu: ${{ steps.filter.outputs.gpu }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4.0.1
+        id: filter
+        with:
+          filters: |
+            gpu:
+              - "src/cuda/**"
+              - "src/python/**"
+              - "**/CMakeLists.txt"
+              - "tests/**"
+              - "install.py"
+              - "pyproject.toml"
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,12 +67,14 @@ jobs:
           pytest -v
 
   build-cuda:
+    needs: [build, changes]
+    if: needs.changes.outputs.gpu == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubu24_T4, win11_x64_T4]
-        python-version: ["3.9"] #["3.9", "3.14"]
-        cuda-version: ["12.8.0"]
+        python-version: ["3.14"]
+        cuda-version: ["13.2.0"]
         include:
           - os: ubu24_T4
             cuda-method: network

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         os: [ubu24_T4, win11_x64_T4]
         python-version: ["3.14"]
-        cuda-version: ["13.2.0"]
+        cuda-version: ["12.8.0"]
         include:
           - os: ubu24_T4
             cuda-method: network

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
       - develop
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
   # trigger on request
   workflow_dispatch:
@@ -22,6 +27,7 @@ env:
 
 jobs:
   changes:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       gpu: ${{ steps.filter.outputs.gpu }}
@@ -40,6 +46,7 @@ jobs:
               - "pyproject.toml"
 
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -68,7 +75,7 @@ jobs:
 
   build-cuda:
     needs: [build, changes]
-    if: needs.changes.outputs.gpu == 'true'
+    if: github.event.pull_request.draft == false && needs.changes.outputs.gpu == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif(ENABLE_CPP)
 # Enable CUDA
 if(ENABLE_CUDA)
     enable_language(CUDA)
-    set(CMAKE_CUDA_STANDARD 11)
+    set(CMAKE_CUDA_STANDARD 17)
     find_package(CUDAToolkit REQUIRED)
 
     # Set CUDA architectures
@@ -56,7 +56,7 @@ if(ENABLE_CUDA)
 endif(ENABLE_CUDA)
 
 if(ENABLE_CPP OR ENABLE_CUDA)
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     # Find pybind11

--- a/src/cuda/ddm_cuda.cc
+++ b/src/cuda/ddm_cuda.cc
@@ -88,10 +88,13 @@ py::array_t<Scalar> PYBIND11_EXPORT ddm_diff_cuda(py::array_t<T, py::array::c_st
     unsigned long long dim_t = max(img_data.length, sf_data.length);
     // Create the output array and get the buffer info
     py::array_t<Scalar> result = py::array_t<Scalar>(dim_t * sf_data.ny * sf_data.nx_half * 2ULL);
-    py::buffer_info result_info = result.request();
 
     // Get pointer to the output array
-    Scalar *result_ptr = static_cast<Scalar *>(result_info.ptr);
+    Scalar *result_ptr; 
+    {
+        py::buffer_info result_info = result.request();
+        result_ptr = static_cast<Scalar *>(result_info.ptr);
+    }
 
     // Compute the FFT2 on the GPU
     compute_fft2(img_seq_ptr,
@@ -246,10 +249,13 @@ py::array_t<Scalar> PYBIND11_EXPORT ddm_fft_cuda(py::array_t<T, py::array::c_sty
     unsigned long long dim_t = max(img_data.length, sf_data.length);
     // Create the output array and get the buffer info
     py::array_t<Scalar> result = py::array_t<Scalar>(dim_t * sf_data.ny * sf_data.nx_half * 2ULL);
-    py::buffer_info result_info = result.request();
 
     // Get pointer to the output array
-    Scalar *result_ptr = static_cast<Scalar *>(result_info.ptr);
+    Scalar *result_ptr; 
+    {
+        py::buffer_info result_info = result.request();
+        result_ptr = static_cast<Scalar *>(result_info.ptr);
+    }
 
     // Compute the FFT2 on the GPU
     compute_fft2(img_seq_ptr,

--- a/src/cuda/helper_ddm_cuda.cu
+++ b/src/cuda/helper_ddm_cuda.cu
@@ -26,29 +26,6 @@ const unsigned long long BLOCK_ROWS = 8; // leave this unchanged!
 /*!
     Convert array from T to double on device and prepare for fft2
 */
-template <typename T>
-__global__ void copy_convert_kernel(T *d_in,
-                                    double *d_out,
-                                    unsigned long long width,
-                                    unsigned long long height,
-                                    unsigned long long length,
-                                    unsigned long long ipitch,
-                                    unsigned long long idist,
-                                    unsigned long long opitch,
-                                    unsigned long long odist)
-{
-    for (unsigned long long t = blockIdx.x; t < length; t += gridDim.x)
-    {
-        for (unsigned long long y = blockIdx.y; y < height; y += gridDim.y)
-        {
-            for (unsigned long long x = threadIdx.x; x < width; x += blockDim.x)
-            {
-                d_out[t * odist + y * opitch + x] = (double)d_in[t * idist + y * ipitch + x];
-            }
-        }
-    }
-}
-
 template __global__ void copy_convert_kernel<uint8_t>(uint8_t *d_in, double *d_out, unsigned long long width, unsigned long long height, unsigned long long length, unsigned long long ipitch, unsigned long long idist, unsigned long long opitch, unsigned long long odist);
 template __global__ void copy_convert_kernel<int16_t>(int16_t *d_in, double *d_out, unsigned long long width, unsigned long long height, unsigned long long length, unsigned long long ipitch, unsigned long long idist, unsigned long long opitch, unsigned long long odist);
 template __global__ void copy_convert_kernel<uint16_t>(uint16_t *d_in, double *d_out, unsigned long long width, unsigned long long height, unsigned long long length, unsigned long long ipitch, unsigned long long idist, unsigned long long opitch, unsigned long long odist);

--- a/src/cuda/helper_ddm_cuda.cuh
+++ b/src/cuda/helper_ddm_cuda.cuh
@@ -46,7 +46,19 @@ __global__ void copy_convert_kernel(T *d_in,
                                     unsigned long long ipitch,
                                     unsigned long long idist,
                                     unsigned long long opitch,
-                                    unsigned long long odist);
+                                    unsigned long long odist)
+{
+    for (unsigned long long t = blockIdx.x; t < length; t += gridDim.x)
+    {
+        for (unsigned long long y = blockIdx.y; y < height; y += gridDim.y)
+        {
+            for (unsigned long long x = threadIdx.x; x < width; x += blockDim.x)
+            {
+                d_out[t * odist + y * opitch + x] = (double)d_in[t * idist + y * ipitch + x];
+            }
+        }
+    }
+}
 
 /*! \brief Apply window function to image sequence
     \param d_in     Image sequence array

--- a/src/cuda/memchk_gpu.cc
+++ b/src/cuda/memchk_gpu.cc
@@ -11,8 +11,11 @@
 // *** headers ***
 #include "memchk_gpu.h"
 
+#include <algorithm>
+
 // system includes
 #ifdef WIN32
+#define NOMINMAX
 #include <windows.h>
 #elif APPLE
 #include <sys/sysinfo.h>
@@ -62,7 +65,7 @@ unsigned long long PYBIND11_EXPORT get_free_host_memory()
 #else
 
     // https://github.com/doleron/cpp-linux-system-stats/blob/main/include/linux-system-usage.hpp
-    ifstream proc_meminfo("/proc/meminfo");
+    std::ifstream proc_meminfo("/proc/meminfo");
 
     if (!proc_meminfo.good())
     {
@@ -70,15 +73,15 @@ unsigned long long PYBIND11_EXPORT get_free_host_memory()
         return 0;
     }
 
-    string content((istreambuf_iterator<char>(proc_meminfo)), istreambuf_iterator<char>());
-    string target = "MemAvailable:";
+    std::string content((std::istreambuf_iterator<char>(proc_meminfo)), std::istreambuf_iterator<char>());
+    std::string target = "MemAvailable:";
     size_t start = content.find(target);
-    if (start != string::npos)
+    if (start != std::string::npos)
     {
         int begin = start + target.length();
         size_t end = content.find("kB", start);
-        string substr = content.substr(begin, end - begin);
-        free_mem = stoull(substr) * 1024;
+        std::string substr = content.substr(begin, end - begin);
+        free_mem = std::stoull(substr) * 1024;
     }
 
 #endif
@@ -107,7 +110,7 @@ unsigned long long PYBIND11_EXPORT get_host_memory_diff(unsigned long long nx,
      */
     unsigned long long mem_required = 0;
 
-    unsigned long long dim_t = max(length * 2, num_lags + 2);
+    unsigned long long dim_t = std::max(length * 2, num_lags + 2);
     mem_required += (nx / 2ULL + 1ULL) * ny * dim_t * SCALAR_SIZE;
 
     return mem_required;

--- a/src/cuda/memchk_gpu.h
+++ b/src/cuda/memchk_gpu.h
@@ -17,8 +17,6 @@
 
 #include "data_struct.h"
 
-using namespace std;
-
 #ifndef SINGLE_PRECISION
 typedef double Scalar;
 #else

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -31,9 +31,13 @@ if IS_CUDA_ENABLED:
         # Get the CUDA Toolkit version
         cuda_version = CUDA_VERSION.split(".")
         cuda_v_major, cuda_v_minor = cuda_version[:2]
-        os.add_dll_directory(
-            os.path.join(os.environ[f"CUDA_PATH_V{cuda_v_major}_{cuda_v_minor}"], "bin")
-        )
+        cuda_bin_path = os.path.join(os.environ[f"CUDA_PATH_V{cuda_v_major}_{cuda_v_minor}"], "bin")
+        os.add_dll_directory(cuda_bin_path)
+
+        # From CUDA Toolkit 13.0 onwards, the DLLs are in the 'bin/x64' subfolder
+        cuda_bin_x64_path = os.path.join(cuda_bin_path, "x64")
+        if os.path.exists(cuda_bin_x64_path):
+            os.add_dll_directory(cuda_bin_x64_path)
 
 from ._ddm import ddm
 from .azimuthalaverage import azimuthal_average, azimuthal_average_array


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->

## Description

Add support for CUDA Toolkit 13:

- [x] Upgrade C++ and CUDA CMake standard to 17
- [x] Include x64 path to added dll directories

## Motivation and context

CUDA Toolkit 13 introduces several important updates to the compiler toolchain and libraries.
This PR adds support to this CUDA Toolkit version while maintaining compatibility with previous ones.

Resolves #274 

## How has this been tested?

This was tested on my machine (Windows 11, python 3.13.9, CUDA Toolkit 13.0.2)
It should be tested using CI pipelines once available.

## Change log

<!-- Propose a change log entry. -->
```
- Add support for CUDA Toolkit 13
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/somexlab/fastddm/blob/main/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**FastDDM Contributor Agreement**](https://github.com/somexlab/fastddm/blob/main/ContributorAgreement.md).
- [x] My name is on the list of contributors (`docs/source/credits.rst`) in the pull request source branch.
