### PR TITLE
👷 Add cuda build and test ci job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubu24_T4] #, win11_x64_T4]
+        os: [uwin11_x64_T44] #[ubu24_T4, win11_x64_T4]
         python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
+        include:
+          # - os: ubu24_T4
+          #   cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
+          #   cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
+          - os: win11_x64_T4
+            cuda-sub-packages: '["nvcc", "cudart", "cufft_dev", "nvml_dev"]'
+            cuda-non-cuda-sub-packages: "[]"
 
     steps:
       - uses: actions/checkout@v4
@@ -65,8 +72,8 @@ jobs:
         with:
           cuda: ${{ matrix.cuda-version }}
           method: network
-          sub-packages: '["nvcc", "cudart", "nvml-dev"]'
-          non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
+          sub-packages: ${{ matrix.cuda-sub-packages }}
+          non-cuda-sub-packages: ${{ matrix.cuda-non-cuda-sub-packages }}
 
       - name: ✅ Verify CUDA installation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          [
-            ubuntu-latest,
-            windows-latest,
-            macos-latest,
-            ubuntu-22.04,
-            macos-13,
-            macos-14,
-          ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.14"]
 
     steps:
@@ -61,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubu24_T4, win11_x64_T4]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
 
     steps:
@@ -72,11 +64,14 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.30
         with:
           cuda: ${{ matrix.cuda-version }}
+          method: network
+          sub-packages: '["nvcc", "cudart", "nvml"]'
+          non-cuda-sub-packages: '["libcufft"]'
 
       - name: ✅ Verify CUDA installation
         run: |
-          echo "CUDA_PATH: ${{ steps.cuda-toolkit.outputs.cuda }}"
-          echo "NVCC_PATH: ${{ steps.cuda-toolkit.outputs.nvcc }}"
+          echo "Installed cuda version is: ${{steps.cuda-toolkit.outputs.cuda}}"
+          echo "Cuda install location: ${{steps.cuda-toolkit.outputs.CUDA_PATH}}"
           nvcc -V
 
       - name: 📦 Install uv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [win11_x64_T4] #[ubu24_T4, win11_x64_T4]
+        os: [ubu24_T4, win11_x64_T4]
         python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
         include:
-          # - os: ubu24_T4
-          #   cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
-          #   cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
+          - os: ubu24_T4
+            cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
+            cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
-            cuda-sub-packages: '["nvcc", "cudart", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
+            cuda-sub-packages: '["nvcc", "cudart", "cufft", "cufft_dev", "nvml", "nvml_dev", "visual_studio_integration"]'
             cuda-non-cuda-sub-packages: "[]"
 
     steps:
@@ -74,6 +74,7 @@ jobs:
           method: network
           sub-packages: ${{ matrix.cuda-sub-packages }}
           non-cuda-sub-packages: ${{ matrix.cuda-non-cuda-sub-packages }}
+          linux-local-args: '["--toolkit"]'
 
       - name: ✅ Verify CUDA installation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,20 +59,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 🧑‍💻 Set up CUDA ${{ matrix.cuda-version }}
-        id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.30
-        with:
-          cuda: ${{ matrix.cuda-version }}
-          method: network
-          sub-packages: '["nvcc", "cudart"]'
-          non-cuda-sub-packages: '["libcufft", "libnvidia-ml"]'
+      # - name: 🧑‍💻 Set up CUDA ${{ matrix.cuda-version }}
+      #   id: cuda-toolkit
+      #   uses: Jimver/cuda-toolkit@v0.2.30
+      #   with:
+      #     cuda: ${{ matrix.cuda-version }}
+      #     method: network
+      #     sub-packages: '["nvcc", "cudart"]'
+      #     non-cuda-sub-packages: '["libcufft", "libnvidia-ml"]'
 
       - name: ✅ Verify CUDA installation
         run: |
-          echo "Installed cuda version is: ${{steps.cuda-toolkit.outputs.cuda}}"
-          echo "Cuda install location: ${{steps.cuda-toolkit.outputs.CUDA_PATH}}"
           nvcc -V
+          nvidia-smi
 
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,11 @@ jobs:
         cuda-version: ["12.8.0"]
         include:
           - os: ubu24_T4
+            cuda-method: network
             cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
             cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
+            cuda-method: local
             cuda-sub-packages: "[]"
             cuda-non-cuda-sub-packages: "[]"
 
@@ -71,10 +73,9 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.34
         with:
           cuda: ${{ matrix.cuda-version }}
-          method: network
+          method: ${{ matrix.cuda-method }}
           sub-packages: ${{ matrix.cuda-sub-packages }}
           non-cuda-sub-packages: ${{ matrix.cuda-non-cuda-sub-packages }}
-          linux-local-args: '["--toolkit"]'
 
       - name: ✅ Verify CUDA installation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           cuda: ${{ matrix.cuda-version }}
           method: network
           sub-packages: '["nvcc", "cudart"]'
-          non-cuda-sub-packages: '["libcufft"]'
+          non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
 
       - name: ✅ Verify CUDA installation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
             cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
-            cuda-sub-packages: '["nvcc", "cudart", "cufft", "cufft_dev", "nvml", "nvml_dev", "visual_studio_integration"]'
+            cuda-sub-packages: '["nvcc", "cudart", "cufft", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
             cuda-non-cuda-sub-packages: "[]"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [win11_x64_T4] #[ubu24_T4, win11_x64_T4]
+        os: [ubu24_T4, win11_x64_T4]
         python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
         include:
-          # - os: ubu24_T4
-          #   cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
-          #   cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
+          - os: ubu24_T4
+            cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
+            cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
-            cuda-sub-packages: "[]" #'["nvcc", "cudart", "cufft", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
+            cuda-sub-packages: "[]"
             cuda-non-cuda-sub-packages: "[]"
 
     steps:
@@ -80,13 +80,6 @@ jobs:
         run: |
           nvcc -V
           nvidia-smi
-
-      - name: 🔍 Debug DLL paths
-        run: |
-          python -c "import os; [print(k,v) for k,v in os.environ.items() if 'CUDA' in k]"
-          dir "$env:CUDA_PATH\bin\*.dll"
-          Get-ChildItem "C:\Program Files\NVIDIA Corporation\NVSMI\*.dll" -ErrorAction SilentlyContinue
-          python -c "import os; [print('Found nvml.dll in:', p) for p in os.environ.get('PATH','').split(os.pathsep) if os.path.isfile(os.path.join(p,'nvml.dll'))]"
 
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubu24_T4, win11_x64_T4]
+        os: [win11_x64_T4] #[ubu24_T4, win11_x64_T4]
         python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
         include:
-          - os: ubu24_T4
-            cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
-            cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
+          # - os: ubu24_T4
+          #   cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
+          #   cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
             cuda-sub-packages: '["nvcc", "cudart", "cufft", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
             cuda-non-cuda-sub-packages: "[]"
@@ -80,6 +80,19 @@ jobs:
         run: |
           nvcc -V
           nvidia-smi
+
+      - name: 🔍 Debug DLL paths
+        run: |
+          python -c "import os; [print(k,v) for k,v in os.environ.items() if 'CUDA' in k]"
+          dir "$env:CUDA_PATH\bin\*.dll"
+          # Check if nvml.dll is in System32
+          dir "C:\Windows\System32\nvml.dll" 2>$null
+          # Check NVIDIA NVSMI directory
+          dir "C:\Program Files\NVIDIA Corporation\NVSMI\nvml.dll" 2>$null
+          # Search for nvml.dll anywhere on the system
+          where.exe nvml.dll 2>$null
+          # Show PATH for reference
+          $env:PATH -split ';' | Select-String -Pattern 'NVIDIA'
 
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           #   cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
           #   cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
-            cuda-sub-packages: '["nvcc", "cudart", "cufft_dev", "nvml_dev"]'
+            cuda-sub-packages: '["nvcc", "cudart", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
             cuda-non-cuda-sub-packages: "[]"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubu24_T4, win11_x64_T4]
+        os: [ubu24_T4] #, win11_x64_T4]
         python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
 
@@ -65,8 +65,8 @@ jobs:
         with:
           cuda: ${{ matrix.cuda-version }}
           method: network
-          sub-packages: '["nvcc", "cudart", "nvml"]'
-          non-cuda-sub-packages: '["libcufft"]'
+          sub-packages: '["nvcc", "cudart"]'
+          non-cuda-sub-packages: '["libcufft", "libnvidia-ml"]'
 
       - name: ✅ Verify CUDA installation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [uwin11_x64_T44] #[ubu24_T4, win11_x64_T4]
+        os: [win11_x64_T4] #[ubu24_T4, win11_x64_T4]
         python-version: ["3.9"] #["3.9", "3.14"]
         cuda-version: ["12.8.0"]
         include:
@@ -68,7 +68,7 @@ jobs:
 
       - name: 🧑‍💻 Set up CUDA ${{ matrix.cuda-version }}
         id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.30
+        uses: Jimver/cuda-toolkit@v0.2.34
         with:
           cuda: ${{ matrix.cuda-version }}
           method: network

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,43 @@ jobs:
       - name: 🧪 Run tests
         run: |
           pytest -v
+
+  build-cuda:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubu24_T4, win11_x64_T4]
+        python-version: ["3.9", "3.14"]
+        cuda-version: ["12.8.0"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 🧑‍💻 Set up CUDA ${{ matrix.cuda-version }}
+        id: cuda-toolkit
+        uses: Jimver/cuda-toolkit@v0.2.30
+        with:
+          cuda: ${{ matrix.cuda-version }}
+
+      - name: ✅ Verify CUDA installation
+        run: |
+          echo "CUDA_PATH: ${{ steps.cuda-toolkit.outputs.cuda }}"
+          echo "NVCC_PATH: ${{ steps.cuda-toolkit.outputs.nvcc }}"
+          nvcc -V
+
+      - name: 📦 Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 🏗️ Build package and install through uv with CUDA support
+        run: |
+          uv pip install --upgrade pip
+          python install.py -v --uv --gpu --extras=test
+
+      - name: 🧪 Run tests with CUDA support
+        run: |
+          pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           cuda: ${{ matrix.cuda-version }}
           method: network
-          sub-packages: '["nvcc", "cudart"]'
+          sub-packages: '["nvcc", "cudart", "nvml-dev"]'
           non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
 
       - name: ✅ Verify CUDA installation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,14 +59,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: 🧑‍💻 Set up CUDA ${{ matrix.cuda-version }}
-      #   id: cuda-toolkit
-      #   uses: Jimver/cuda-toolkit@v0.2.30
-      #   with:
-      #     cuda: ${{ matrix.cuda-version }}
-      #     method: network
-      #     sub-packages: '["nvcc", "cudart"]'
-      #     non-cuda-sub-packages: '["libcufft", "libnvidia-ml"]'
+      - name: 🧑‍💻 Set up CUDA ${{ matrix.cuda-version }}
+        id: cuda-toolkit
+        uses: Jimver/cuda-toolkit@v0.2.30
+        with:
+          cuda: ${{ matrix.cuda-version }}
+          method: network
+          sub-packages: '["nvcc", "cudart"]'
+          non-cuda-sub-packages: '["libcufft"]'
 
       - name: ✅ Verify CUDA installation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           #   cuda-sub-packages: '["nvcc", "cudart", "nvml-dev"]'
           #   cuda-non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
           - os: win11_x64_T4
-            cuda-sub-packages: '["nvcc", "cudart", "cufft", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
+            cuda-sub-packages: "[]" #'["nvcc", "cudart", "cufft", "cufft_dev", "nvml_dev", "visual_studio_integration"]'
             cuda-non-cuda-sub-packages: "[]"
 
     steps:
@@ -85,14 +85,8 @@ jobs:
         run: |
           python -c "import os; [print(k,v) for k,v in os.environ.items() if 'CUDA' in k]"
           dir "$env:CUDA_PATH\bin\*.dll"
-          # Check if nvml.dll is in System32
-          dir "C:\Windows\System32\nvml.dll" 2>$null
-          # Check NVIDIA NVSMI directory
-          dir "C:\Program Files\NVIDIA Corporation\NVSMI\nvml.dll" 2>$null
-          # Search for nvml.dll anywhere on the system
-          where.exe nvml.dll 2>$null
-          # Show PATH for reference
-          $env:PATH -split ';' | Select-String -Pattern 'NVIDIA'
+          Get-ChildItem "C:\Program Files\NVIDIA Corporation\NVSMI\*.dll" -ErrorAction SilentlyContinue
+          python -c "import os; [print('Found nvml.dll in:', p) for p in os.environ.get('PATH','').split(os.pathsep) if os.path.isfile(os.path.join(p,'nvml.dll'))]"
 
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Description

This pull request adds a CI job that builds the package with GPU support and runs the test suite on GPU-enabled runners.

## Motivation and context

Including GPU builds and tests in CI helps validate CUDA code on real hardware and catches GPU-specific regressions earlier in the development cycle.

## Notes

This PR pins the CUDA toolkit to version `12.8.0` for compatibility with the current setup. The toolkit version will be updated in #275 

Resolves #259 

## Change log

```
- Add GPU build and test CI job 
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/somexlab/fastddm/blob/main/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**FastDDM Contributor Agreement**](https://github.com/somexlab/fastddm/blob/main/ContributorAgreement.md).
- [x] My name is on the list of contributors (`docs/source/credits.rst`) in the pull request source branch.
